### PR TITLE
env.example file updated

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,6 +18,9 @@ JWT_REFRESH_EXPIRE=30d
 # Groq AI (Free LLM API - https://console.groq.com)
 GROQ_API_KEY=your_groq_api_key_here
 
+# Required for RAG (Converting Resumes & JDs to Vector Embeddings)
+OPENAI_API_KEY=your_actual_openai_api_key_here
+
 # Cloudinary (Resume/File Storage)
 CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
 CLOUDINARY_API_KEY=your_cloudinary_api_key


### PR DESCRIPTION
In the project, the Open-API-Key is also used. Required for RAG (Converting Resumes & JDs to Vector Embeddings)